### PR TITLE
 #43: Add missing slash in websockets URL.

### DIFF
--- a/ofmeet/changelog.html
+++ b/ofmeet/changelog.html
@@ -57,6 +57,7 @@
     <li>Fix the change in meeting URLs from version 0.3.x to 0.9.x</li>
     <li>Finishing the Quartz CRON job triggers for meetings.</li>
     <li>Add support for notifications via IM as used by Pade.</li>
+    <li>Uses <a href="https://github.com/igniterealtime/ofmeet-openfire-plugin/issues/49">websocket when using Openfire 4.2.0 or later</a>.</li>
 </ul>
 
 <p><b>0.9.2</b> -- <i>August 15, 2017</i></p>

--- a/ofmeet/changelog.html
+++ b/ofmeet/changelog.html
@@ -57,6 +57,7 @@
     <li>Fix the change in meeting URLs from version 0.3.x to 0.9.x</li>
     <li>Finishing the Quartz CRON job triggers for meetings.</li>
     <li>Add support for notifications via IM as used by Pade.</li>
+    <li>Adds <a href="https://github.com/igniterealtime/ofmeet-openfire-plugin/issues/43">missing closing slash</a> in websocket URL.</li>
     <li>Uses <a href="https://github.com/igniterealtime/ofmeet-openfire-plugin/issues/49">websocket when using Openfire 4.2.0 or later</a>.</li>
 </ul>
 

--- a/web/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/ConfigServlet.java
+++ b/web/src/main/java/org/jivesoftware/openfire/plugin/ofmeet/ConfigServlet.java
@@ -301,7 +301,7 @@ public class ConfigServlet extends HttpServlet
                 websocketScheme = "ws";
             }
 
-            return new URI( websocketScheme, null, request.getServerName(), request.getServerPort(), "/ws", null, null);
+            return new URI( websocketScheme, null, request.getServerName(), request.getServerPort(), "/ws/", null, null);
         }
         else
         {


### PR DESCRIPTION
Note that this PR is based on the fix for #49. Perhaps merge #50 before merging this PR.